### PR TITLE
Add more haskell implementations

### DIFF
--- a/data/impl_tags.yaml
+++ b/data/impl_tags.yaml
@@ -125,3 +125,18 @@
   haskell:
     label: Haskell
     logo: haskell.png
+  scotty:
+    label: Scotty
+    logo: no-logo.svg
+  servant:
+    label: Servant
+    logo: no-logo.svg
+  snap:
+    label: Snap
+    logo: no-logo.svg
+  spock:
+    label: Spock
+    logo: no-logo.svg
+  yesod:
+    label: Yesod
+    logo: no-logo.svg

--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -329,14 +329,6 @@
     - phoenix
     - postgres
 
-"Haskell - Scotty / Persistent":
-  description:
-      Haskell implementation using <a href="http://hackage.haskell.org/package/scotty">Scotty</a>.
-  live_url: http://todobackend-scotty.herokuapp.com/todos
-  sourcecode_url: https://github.com/jhedev/todobackend-scotty-persistent
-  tags:
-    - haskell
-    - scotty
 
 "Java - Axon + Spring Boot":
   description:
@@ -357,3 +349,48 @@
   tags:
     - python
     - flask
+
+"Haskell - Scotty / Persistent":
+  description:
+      Haskell implementation using <a href="http://hackage.haskell.org/package/scotty">Scotty</a>.
+  live_url: http://todobackend-scotty.sloppy.zone/todos
+  sourcecode_url: https://github.com/jhedev/todobackend-haskell/tree/master/todobackend-scotty
+  tags:
+    - haskell
+    - scotty
+
+"Haskell - Servant / Persistent":
+  description:
+      Haskell implementation using <a href="http://haskell-servant.github.io/">Servant</a>.
+  live_url: http://todobackend-servant.sloppy.zone/todos
+  sourcecode_url: https://github.com/jhedev/todobackend-haskell/tree/master/todobackend-servant
+  tags:
+    - haskell
+    - servant
+
+"Haskell - Snap / Persistent":
+  description:
+      Haskell implementation using <a href="http://snapframework.com/">Snap</a>.
+  live_url: http://todobackend-snap.sloppy.zone/todos
+  sourcecode_url: https://github.com/jhedev/todobackend-haskell/tree/master/todobackend-snap
+  tags:
+    - haskell
+    - snap
+
+"Haskell - Spock / Persistent":
+  description:
+      Haskell implementation using <a href="https://www.spock.li/">Spock</a>.
+  live_url: http://todobackend-spock.sloppy.zone/todos
+  sourcecode_url: https://github.com/jhedev/todobackend-haskell/tree/master/todobackend-spock
+  tags:
+    - haskell
+    - spock
+
+"Haskell - Yesod / Persistent":
+  description:
+      Haskell implementation using <a href="http://www.yesodweb.com/">Yesod</a>.
+  live_url: http://todobackend-yesod.sloppy.zone/todos
+  sourcecode_url: https://github.com/jhedev/todobackend-haskell/tree/master/todobackend-yesod
+  tags:
+    - haskell
+    - yesod


### PR DESCRIPTION
I've updated my previously submitted implementation (Haskell + Scotty) and added a few more implementations using other Haskell frameworks.

There are now implementations for [Scotty](http://hackage.haskell.org/package/scotty), [Servant](http://haskell-servant.github.io/), [Snap](http://snapframework.com/), [Spock](https://www.spock.li/) and [Yesod](http://www.yesodweb.com/). 

Tests for my implementations:
* [scotty](http://www.todobackend.com/specs/index.html?http://todobackend-scotty.sloppy.zone/todos)
* [servant](http://www.todobackend.com/specs/index.html?http://todobackend-servant.sloppy.zone/todos)
* [snap](http://www.todobackend.com/specs/index.html?http://todobackend-snap.sloppy.zone/todos)
* [spock](http://www.todobackend.com/specs/index.html?http://todobackend-spock.sloppy.zone/todos)
* [yesod](http://www.todobackend.com/specs/index.html?http://todobackend-yesod.sloppy.zone/todos)

Still need to check if I can add the corresponding logos. I'll update this PR as soon as I've done that :)