### PR TITLE
Add Elixir - Maru / Postgres implementation

### DIFF
--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -338,6 +338,16 @@
     - phoenix
     - postgres
 
+"Elixir - Maru / Postgres":
+  description:
+    <a href="http://elixir-lang.org">Elixir</a> implementation using the <a href="https://maru.readme.io/">Maru Framework</a> backed by Postgres. Deployed to Heroku using the Elixir buildpack. Courtesy of <a href="http://jeffweiss.org">Jeff Weiss</a>
+  live_url: http://maru-todo.herokuapp.com/tasks
+  sourcecode_url: https://github.com/whitfieldc/maru_todo
+  tags:
+    - elixir
+    - maru
+    - postgres
+
 
 "Java - Axon + Spring Boot":
   description:


### PR DESCRIPTION
I've written an implementation with Elixir's micro-framework Maru and the Ecto ORM with Postgres. Right now the code is pretty disorganized, but I'm planning to break the modules out into a better file structure.

It's live at http://maru-todo.herokuapp.com and the testing link is http://todobackend.com/specs/index.html?http://maru-todo.herokuapp.com/tasks

If you need anything else for this, please let me know! 