### PR TITLE
PHP implementation using Slim 3 and Spot

### DIFF
--- a/data/impl_tags.yaml
+++ b/data/impl_tags.yaml
@@ -162,3 +162,6 @@
   symfony2:
     label: Symfony2
     logo: symfony.svg
+  slim:
+    label: Slim
+    logo: no-logo.svg

--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -478,7 +478,7 @@
     - nodejs
     - restify
     - redux
-    
+
 "TypeScript / Node.js / Express":
   description:
     <a href="http://www.typescriptlang.org/">TypeScript</a> + <a href="http://nodejs.org/">Node.js</a> + Express, saving to Postgres.
@@ -489,3 +489,12 @@
     - nodejs
     - expressjs
     - postgres
+
+"Slim 3 / Spot":
+  description:
+    PHP implementation with <a href="http://www.slimframework.com/">Slim 3</a> and <a href="http://phpdatamapper.com/">Spot</a>.
+  sourcecode_url: https://github.com/tuupola/slim-todo-backend/
+  live_url: http://slim3-todo-backend.appelsiini.net/todos
+  tags:
+    - php
+    - slim


### PR DESCRIPTION
This PR adds Slim 3 implementation as requested in #12. Uses [Spot](http://phpdatamapper.com/) as persistence layer.