### PR TITLE
Remove Swift / Kitura from list (duplicate)

### DIFF
--- a/data/implementations.yaml
+++ b/data/implementations.yaml
@@ -632,16 +632,6 @@
     - jvm
     - fintrospect
 
-"Swift / Kitura":
-  description:
-    A <a href="http://www.swift.org">Swift</a> implementation using
-    <a href="https://github.com/IBM-Swift/Kitura">Kitura</a> for web.
-  sourcecode_url: https://github.com/IBM-Swift/Kitura-TodoList
-  live_url: https://kitura-todolist.mybluemix.net/
-  tags:
-    - swift
-    - kitura
-
 "Swift / Kitura / Postgres":
   description: A <a href="http://www.swift.org">Swift</a> implementation using <a href="https://github.com/IBM-Swift/Kitura">Kitura</a> for web.
   sourcecode_url: https://github.com/IBM-Swift/todolist-postgresql


### PR DESCRIPTION
'Swift / Kitura' uses the same backend as 'Swift / Kitura / CouchDB' and the different route it used was removed.